### PR TITLE
Refactor/22 testing infrastructure hardeining

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -4,6 +4,7 @@ go 1.26.1
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5
+	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/joho/godotenv v1.5.1
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.2.5 h1:Eg4myHZBjyvJmAFjFvWgrqDTXFyOzjj7YIm3L3mu6Ug=
 github.com/go-chi/chi/v5 v5.2.5/go.mod h1:X7Gx4mteadT3eDOMTsXzmI4/rwUpOwBHLpAfupzFJP0=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/internal/database/dbtx.go
+++ b/backend/internal/database/dbtx.go
@@ -1,4 +1,4 @@
-package repository
+package database
 
 import (
 	"context"

--- a/backend/internal/handler/audit_event_handler_test.go
+++ b/backend/internal/handler/audit_event_handler_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/florantos/orbital-command/internal/domain"
 	"github.com/florantos/orbital-command/internal/handler"
+	"github.com/florantos/orbital-command/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -31,7 +32,7 @@ func (m *mockAuditEventRepo) ReadAll(ctx context.Context) ([]domain.AuditEvent, 
 	return m.readAllFn(ctx)
 }
 
-func TestAuditEvent_Handler_Returns200(t *testing.T) {
+func TestAuditEventHandler_ReadAll_Returns200(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []domain.AuditEvent
@@ -39,23 +40,8 @@ func TestAuditEvent_Handler_Returns200(t *testing.T) {
 		{
 			name: "returns audit events on success",
 			input: []domain.AuditEvent{
-				{
-					ID:         "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-					Action:     "module.registered",
-					EntityType: "module",
-					EntityID:   "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380b12",
-					Actor:      "Commander Chen",
-					Detail:     "Registered module: Navigation Array",
-				},
-
-				{
-					ID:         "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13",
-					Action:     "Navigation Array",
-					EntityType: "module",
-					EntityID:   "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380b14",
-					Actor:      "System",
-					Detail:     "Registered module: Navigation Array2",
-				},
+				*testutil.NewTestAuditEvent(t),
+				*testutil.NewTestAuditEvent(t),
 			},
 		},
 		{
@@ -94,7 +80,7 @@ func TestAuditEvent_Handler_Returns200(t *testing.T) {
 	}
 
 }
-func TestAuditEvent_Handler_Returns500OnUnexpectedError(t *testing.T) {
+func TestAuditEventHandler_ReadAll_Returns500OnUnexpectedError(t *testing.T) {
 	auditEventRepo := &mockAuditEventRepo{
 		readAllFn: func(ctx context.Context) ([]domain.AuditEvent, error) {
 			return []domain.AuditEvent{}, fmt.Errorf("read all audit events: unexpected database error")

--- a/backend/internal/handler/module_handler_test.go
+++ b/backend/internal/handler/module_handler_test.go
@@ -300,7 +300,7 @@ func TestModuleHandler_Create_EmitsAuditEventOnSuccess(t *testing.T) {
 	assert.Equal(t, string(returnedModule.HealthState), response.HealthState)
 }
 
-func TestModulesHandler_ReadAll_Returns500OnUnexpectedError(t *testing.T) {
+func TestModuleHandler_ReadAll_Returns500OnUnexpectedError(t *testing.T) {
 	moduleRepo := &mockModuleRepo{
 		readAllFn: func(ctx context.Context) ([]domain.Module, error) {
 			return []domain.Module{}, fmt.Errorf("read all modules: unexpected database error")

--- a/backend/internal/handler/module_handler_test.go
+++ b/backend/internal/handler/module_handler_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/florantos/orbital-command/internal/domain"
 	"github.com/florantos/orbital-command/internal/handler"
+	"github.com/florantos/orbital-command/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,13 +31,8 @@ func (m *mockModuleRepo) ReadAll(ctx context.Context) ([]domain.Module, error) {
 	return m.readAllFn(ctx)
 }
 
-func TestCreateModuleHandler_Returns201OnSuccess(t *testing.T) {
-	returnedModule := &domain.Module{
-		ID:          "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-		Name:        "Navigation Array",
-		Description: "Controls navigation systems",
-		HealthState: domain.HealthStateOperational,
-	}
+func TestModuleHandler_Create_Returns201OnSuccess(t *testing.T) {
+	returnedModule := testutil.NewTestModule(t)
 
 	moduleRepo := &mockModuleRepo{
 		createFn: func(ctx context.Context, module *domain.Module) (*domain.Module, error) {
@@ -79,7 +75,7 @@ func TestCreateModuleHandler_Returns201OnSuccess(t *testing.T) {
 	assert.Equal(t, string(returnedModule.HealthState), response.HealthState)
 }
 
-func TestCreateModuleHandler_Returns400OnMalformedJSON(t *testing.T) {
+func TestModuleHandler_Create_Returns400OnMalformedJSON(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	h := handler.NewHandler(logger, nil, nil)
 
@@ -104,7 +100,7 @@ func TestCreateModuleHandler_Returns400OnMalformedJSON(t *testing.T) {
 	assert.Equal(t, "malformed request body", response.Error)
 }
 
-func TestCreateModuleHandler_Returns409OnDuplicateName(t *testing.T) {
+func TestModuleHandler_Create_Returns409OnDuplicateName(t *testing.T) {
 	moduleRepo := &mockModuleRepo{
 		createFn: func(ctx context.Context, module *domain.Module) (*domain.Module, error) {
 			return nil, fmt.Errorf("create module: %w", domain.ErrDuplicateModuleName)
@@ -138,7 +134,7 @@ func TestCreateModuleHandler_Returns409OnDuplicateName(t *testing.T) {
 
 }
 
-func TestCreateModuleHandler_Returns500OnUnexpectedError(t *testing.T) {
+func TestModuleHandler_Create_Returns500OnUnexpectedError(t *testing.T) {
 	moduleRepo := &mockModuleRepo{
 		createFn: func(ctx context.Context, module *domain.Module) (*domain.Module, error) {
 			return nil, fmt.Errorf("create module: unexpected database error")
@@ -171,7 +167,7 @@ func TestCreateModuleHandler_Returns500OnUnexpectedError(t *testing.T) {
 	assert.Equal(t, "internal server error", response.Error)
 }
 
-func TestCreateModuleHandler_Returns422OnValidationFailure(t *testing.T) {
+func TestModuleHandler_Create_Returns422OnValidationFailure(t *testing.T) {
 	tests := []struct {
 		name           string
 		reqBody        handler.CreateModuleRequest
@@ -258,13 +254,8 @@ func TestCreateModuleHandler_Returns422OnValidationFailure(t *testing.T) {
 	}
 }
 
-func TestCreateModuleHandler_EmitsAuditEventOnSuccess(t *testing.T) {
-	returnedModule := &domain.Module{
-		ID:          "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-		Name:        "Navigation Array",
-		Description: "Controls navigation systems",
-		HealthState: domain.HealthStateOperational,
-	}
+func TestModuleHandler_Create_EmitsAuditEventOnSuccess(t *testing.T) {
+	returnedModule := testutil.NewTestModule(t)
 
 	moduleRepo := &mockModuleRepo{
 		createFn: func(ctx context.Context, module *domain.Module) (*domain.Module, error) {
@@ -309,7 +300,7 @@ func TestCreateModuleHandler_EmitsAuditEventOnSuccess(t *testing.T) {
 	assert.Equal(t, string(returnedModule.HealthState), response.HealthState)
 }
 
-func TestReadAllModulesHandler_Returns500OnUnexpectedError(t *testing.T) {
+func TestModulesHandler_ReadAll_Returns500OnUnexpectedError(t *testing.T) {
 	moduleRepo := &mockModuleRepo{
 		readAllFn: func(ctx context.Context) ([]domain.Module, error) {
 			return []domain.Module{}, fmt.Errorf("read all modules: unexpected database error")
@@ -335,7 +326,7 @@ func TestReadAllModulesHandler_Returns500OnUnexpectedError(t *testing.T) {
 
 }
 
-func TestReadAllModulesHandler_Returns200(t *testing.T) {
+func TestModulesHandler_ReadAll_Returns200(t *testing.T) {
 	tests := []struct {
 		name  string
 		input []domain.Module
@@ -343,14 +334,8 @@ func TestReadAllModulesHandler_Returns200(t *testing.T) {
 		{
 			name: "returns modules on success",
 			input: []domain.Module{
-				{ID: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
-					Name:        "Navigation Array",
-					Description: "Controls navigation systems",
-					HealthState: domain.HealthStateOperational},
-				{ID: "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12",
-					Name:        "Navigation Array2",
-					Description: "Controls navigation systems2",
-					HealthState: domain.HealthStateOperational},
+				*testutil.NewTestModule(t),
+				*testutil.NewTestModule(t),
 			},
 		},
 		{

--- a/backend/internal/repository/audit_event_repo.go
+++ b/backend/internal/repository/audit_event_repo.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/florantos/orbital-command/internal/database"
 	"github.com/florantos/orbital-command/internal/domain"
 )
 
 type AuditEventRepo struct {
-	db DBTX
+	db database.DBTX
 }
 
-func NewAuditEventRepo(db DBTX) *AuditEventRepo {
+func NewAuditEventRepo(db database.DBTX) *AuditEventRepo {
 	return &AuditEventRepo{db: db}
 
 }

--- a/backend/internal/repository/audit_event_repo_test.go
+++ b/backend/internal/repository/audit_event_repo_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestAuditEventRepo_Create_PersistsAuditEvent(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewAuditEventRepo(tx)
 
 	event := domain.NewAuditEvent("module.registered", "module", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "Commander Chen", "Registered module: Navigation Array")
@@ -25,8 +24,7 @@ func TestAuditEventRepo_Create_PersistsAuditEvent(t *testing.T) {
 }
 
 func TestAuditEventRepo_ReadAll_ReturnsAllEvents(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewAuditEventRepo(tx)
 
 	event := domain.NewAuditEvent("module.registered", "module", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "System", "Registered module: Navigation Array2")
@@ -45,8 +43,7 @@ func TestAuditEventRepo_ReadAll_ReturnsAllEvents(t *testing.T) {
 }
 
 func TestAuditEventRepo_ReadAll_ReturnsEmptyArrayWhenNoEvents(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewAuditEventRepo(tx)
 
 	events, err := repo.ReadAll(context.Background())

--- a/backend/internal/repository/audit_event_repo_test.go
+++ b/backend/internal/repository/audit_event_repo_test.go
@@ -15,8 +15,7 @@ func TestAuditEventRepo_Create_PersistsAuditEvent(t *testing.T) {
 	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewAuditEventRepo(tx)
 
-	event := domain.NewAuditEvent("module.registered", "module", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "Commander Chen", "Registered module: Navigation Array")
-
+	event := testutil.NewTestAuditEvent(t)
 	err := repo.Create(context.Background(), event)
 
 	require.NoError(t, err)
@@ -27,18 +26,15 @@ func TestAuditEventRepo_ReadAll_ReturnsAllEvents(t *testing.T) {
 	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewAuditEventRepo(tx)
 
-	event := domain.NewAuditEvent("module.registered", "module", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12", "System", "Registered module: Navigation Array2")
-	event2 := domain.NewAuditEvent("module.registered", "module", "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", "Commander Chen", "Registered module: Navigation Array")
+	events := make([]*domain.AuditEvent, 10)
+	for i := range events {
+		events[i] = testutil.NewTestAuditEvent(t)
+	}
+	testutil.SeedAuditEvents(t, tx, events)
 
-	err := repo.Create(t.Context(), event)
+	result, err := repo.ReadAll(context.Background())
 	require.NoError(t, err)
-	err = repo.Create(t.Context(), event2)
-	require.NoError(t, err)
-
-	events, err := repo.ReadAll(context.Background())
-	require.NoError(t, err)
-
-	assert.Len(t, events, 2)
+	assert.Len(t, result, 10)
 
 }
 

--- a/backend/internal/repository/module_repo.go
+++ b/backend/internal/repository/module_repo.go
@@ -5,15 +5,16 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/florantos/orbital-command/internal/database"
 	"github.com/florantos/orbital-command/internal/domain"
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
 type ModuleRepo struct {
-	db DBTX
+	db database.DBTX
 }
 
-func NewModuleRepo(db DBTX) *ModuleRepo {
+func NewModuleRepo(db database.DBTX) *ModuleRepo {
 	return &ModuleRepo{db: db}
 }
 

--- a/backend/internal/repository/module_repo_test.go
+++ b/backend/internal/repository/module_repo_test.go
@@ -15,8 +15,7 @@ func TestModuleRepo_Create_PersistsAndReturnsModule(t *testing.T) {
 	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
-	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
-	require.NoError(t, err)
+	module := testutil.NewTestModule(t)
 
 	created, err := repo.Create(context.Background(), module)
 
@@ -34,10 +33,9 @@ func TestModuleRepo_Create_ReturnsErrorOnDuplicateName(t *testing.T) {
 	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
-	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
-	require.NoError(t, err)
+	module := testutil.NewTestModule(t)
 
-	_, err = repo.Create(context.Background(), module)
+	_, err := repo.Create(context.Background(), module)
 	require.NoError(t, err)
 
 	_, err = repo.Create(context.Background(), module)
@@ -49,20 +47,16 @@ func TestModuleRepo_ReadAll_ReturnsAllModules(t *testing.T) {
 	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
-	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
-	require.NoError(t, err)
-	_, err = repo.Create(context.Background(), module)
+	modules := make([]*domain.Module, 10)
+	for i := range modules {
+		modules[i] = testutil.NewTestModule(t)
+	}
+	testutil.SeedModules(t, tx, modules)
+
+	result, err := repo.ReadAll(context.Background())
 	require.NoError(t, err)
 
-	module2, err := domain.NewModule("Navigation Array2", "Controls navigation systems2")
-	require.NoError(t, err)
-	_, err = repo.Create(context.Background(), module2)
-	require.NoError(t, err)
-
-	modules, err := repo.ReadAll(context.Background())
-	require.NoError(t, err)
-
-	assert.Len(t, modules, 2)
+	assert.Len(t, result, 10)
 
 }
 func TestModuleRepo_ReadAll_ReturnsEmptyArrayWhenNoModules(t *testing.T) {

--- a/backend/internal/repository/module_repo_test.go
+++ b/backend/internal/repository/module_repo_test.go
@@ -12,8 +12,7 @@ import (
 )
 
 func TestModuleRepo_Create_PersistsAndReturnsModule(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
 	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
@@ -32,8 +31,7 @@ func TestModuleRepo_Create_PersistsAndReturnsModule(t *testing.T) {
 }
 
 func TestModuleRepo_Create_ReturnsErrorOnDuplicateName(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
 	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
@@ -48,8 +46,7 @@ func TestModuleRepo_Create_ReturnsErrorOnDuplicateName(t *testing.T) {
 }
 
 func TestModuleRepo_ReadAll_ReturnsAllModules(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
 	module, err := domain.NewModule("Navigation Array", "Controls navigation systems")
@@ -69,8 +66,7 @@ func TestModuleRepo_ReadAll_ReturnsAllModules(t *testing.T) {
 
 }
 func TestModuleRepo_ReadAll_ReturnsEmptyArrayWhenNoModules(t *testing.T) {
-	pool := testutil.NewTestPool(t)
-	tx := testutil.NewTestTx(t, pool)
+	tx := testutil.NewTestTx(t, testPool)
 	repo := repository.NewModuleRepo(tx)
 
 	modules, err := repo.ReadAll(context.Background())

--- a/backend/internal/repository/setup_test.go
+++ b/backend/internal/repository/setup_test.go
@@ -1,0 +1,25 @@
+package repository_test
+
+import (
+	"context"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var testPool *pgxpool.Pool
+
+func TestMain(m *testing.M) {
+	var err error
+	testPool, err = pgxpool.New(context.Background(), os.Getenv("TEST_DATABASE_URL"))
+	if err != nil {
+		log.Fatalf("failed to create test pool: %v", err)
+	}
+
+	code := m.Run()
+
+	testPool.Close()
+	os.Exit(code)
+}

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"testing"
 
+	"github.com/florantos/orbital-command/internal/database"
+	"github.com/florantos/orbital-command/internal/domain"
+	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
@@ -23,4 +26,59 @@ func NewTestTx(t *testing.T, pool *pgxpool.Pool) pgx.Tx {
 	})
 
 	return tx
+}
+
+func NewTestModule(t *testing.T, opts ...func(*domain.Module)) *domain.Module {
+	t.Helper()
+	m, err := domain.NewModule(
+		"Test Module"+uuid.NewString()[:8],
+		"Test Description"+uuid.NewString()[:8],
+	)
+	require.NoError(t, err)
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+func SeedModules(t *testing.T, db database.DBTX, modules []*domain.Module) {
+	query := `
+		INSERT INTO modules (name, description, health_state) 
+		VALUES ($1, $2, $3)
+	`
+	for _, m := range modules {
+		_, err := db.Exec(context.Background(), query, m.Name, m.Description, m.HealthState)
+		if err != nil {
+			t.Fatalf("seeding modules: %v", err)
+		}
+	}
+}
+
+func NewTestAuditEvent(t *testing.T, opts ...func(*domain.AuditEvent)) *domain.AuditEvent {
+	t.Helper()
+	ae := domain.NewAuditEvent(
+		"module.registered",
+		"module",
+		uuid.NewString(),
+		"Commander Chen",
+		"Registered module: Navigation Array",
+	)
+	for _, opt := range opts {
+		opt(ae)
+	}
+	return ae
+}
+
+func SeedAuditEvents(t *testing.T, db database.DBTX, auditEvents []*domain.AuditEvent) {
+	t.Helper()
+	query := `
+		INSERT INTO audit_events (action, entity_type, entity_id, actor, detail) 
+		VALUES ($1, $2, $3, $4, $5)
+	`
+	for _, ae := range auditEvents {
+		_, err := db.Exec(context.Background(), query, ae.Action, ae.EntityType, ae.EntityID, ae.Actor, ae.Detail)
+		if err != nil {
+			t.Fatalf("seeding audit events: %v", err)
+		}
+	}
 }

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -42,6 +42,7 @@ func NewTestModule(t *testing.T, opts ...func(*domain.Module)) *domain.Module {
 }
 
 func SeedModules(t *testing.T, db database.DBTX, modules []*domain.Module) {
+	t.Helper()
 	query := `
 		INSERT INTO modules (name, description, health_state) 
 		VALUES ($1, $2, $3)

--- a/backend/internal/testutil/db.go
+++ b/backend/internal/testutil/db.go
@@ -2,26 +2,12 @@ package testutil
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/stretchr/testify/require"
 )
-
-func NewTestPool(t *testing.T) *pgxpool.Pool {
-	t.Helper()
-
-	pool, err := pgxpool.New(context.Background(), os.Getenv("TEST_DATABASE_URL"))
-	require.NoError(t, err)
-
-	t.Cleanup(func() {
-		pool.Close()
-	})
-
-	return pool
-}
 
 func NewTestTx(t *testing.T, pool *pgxpool.Pool) pgx.Tx {
 	t.Helper()


### PR DESCRIPTION
## Story

Closes #22 

## What was built

Create TestMain func with a single db connection to use for all tests.  Add test helper functions for create and bulk insert for audit events and modules.

## Acceptance Criteria

- [x] All repository tests share a single database connection pool for the entire test run rather than creating a new pool per test
- [x] Each repository test runs in an isolated transaction that is rolled back after the test completes
- [x] Related test cases within a single test function are grouped as subtests
- [x] A helper function exists for creating valid test entities with sensible defaults that can be selectively overridden
- [x] A bulk data insert approach is established and demonstrated in at least one test that requires more than a trivial number of rows


## Notes

